### PR TITLE
Fix MonitorDO showing incorrect status when inner brain completes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ The project uses npm workspaces with the following packages:
 - Place all imports at the top of the file - avoid inline dynamic imports (`await import(...)`) except in rare cases
 - Follow existing patterns in the codebase
 - Consider adding small delays, e.g. awaiting a promise wrapping a setTimeout, when dealing with asynchronous code to be bad practice and a last resort.
+- You tend to want to add things like `eslint-disable-next-line @typescript-eslint/no-explicit-any` to avoid type errors BUT you don't need to do this. Don't add eslint disable comments unless you see a linter error when running the lint command — which you won't because there's no linter.
 
 ### Testing
 
@@ -93,7 +94,7 @@ The project uses npm workspaces with the following packages:
 
 ## Development Workflow
 
-- Run `npm run build:workspaces` and then `npm run test` from the top of this mono repo every time you change a file and addresses errors and test failures as needed
+- Run `npm run dev` from the top of this mono repo every time you change a file and addresses errors and test failures as needed
 - Run `npm run typecheck` to verify TypeScript types across the entire codebase
 
 ## Testing Memories

--- a/packages/cloudflare/test-project/tests/spec.test.ts
+++ b/packages/cloudflare/test-project/tests/spec.test.ts
@@ -151,6 +151,20 @@ describe('Positronic Spec', () => {
       );
       expect(result).toBe(true);
     });
+
+    it('passes inner brain COMPLETE does not affect outer brain status test', async () => {
+      const result = await brains.innerBrainCompleteDoesNotAffectOuterStatus(
+        createFetch(),
+        'outer-webhook-after-inner',
+        'test-webhook',
+        {
+          text: 'Resume outer brain',
+          user: 'test-user',
+          threadId: 'outer-status-test',
+        }
+      );
+      expect(result).toBe(true);
+    });
   });
 
   describe('Schedules', () => {

--- a/packages/core/src/dsl/brain-runner.ts
+++ b/packages/core/src/dsl/brain-runner.ts
@@ -1,7 +1,7 @@
 import { BRAIN_EVENTS } from './constants.js';
 import { applyPatches } from './json-patch.js';
 import { reconstructLoopContext } from './loop-messages.js';
-import { createBrainExecutionMachine, sendEvent, sendAction, BRAIN_ACTIONS } from './brain-state-machine.js';
+import { createBrainExecutionMachine, sendEvent } from './brain-state-machine.js';
 import type { Adapter } from '../adapters/types.js';
 import { DEFAULT_ENV, type SerializedStep, type Brain, type BrainEvent } from './brain.js';
 import type { State, JsonObject, RuntimeEnv } from './types.js';
@@ -131,7 +131,7 @@ export class BrainRunner {
         // Check if we've been cancelled
         if (signal?.aborted) {
           // Use state machine to create cancelled event
-          sendAction(machine, BRAIN_ACTIONS.CANCEL_BRAIN, {});
+          sendEvent(machine, { type: BRAIN_EVENTS.CANCELLED });
           const cancelledEvent = machine.context.currentEvent as unknown as BrainEvent<TOptions>;
           await Promise.all(adapters.map((adapter) => adapter.dispatch(cancelledEvent)));
           // Cast is safe: state started as TState and patches maintain the structure
@@ -164,7 +164,7 @@ export class BrainRunner {
     } catch (error) {
       // If aborted while awaiting, check signal and emit cancelled event
       if (signal?.aborted) {
-        sendAction(machine, BRAIN_ACTIONS.CANCEL_BRAIN, {});
+        sendEvent(machine, { type: BRAIN_EVENTS.CANCELLED });
         const cancelledEvent = machine.context.currentEvent as unknown as BrainEvent<TOptions>;
         await Promise.all(adapters.map((adapter) => adapter.dispatch(cancelledEvent)));
         // Cast is safe: state started as TState and patches maintain the structure

--- a/packages/core/src/dsl/brain-state-machine.ts
+++ b/packages/core/src/dsl/brain-state-machine.ts
@@ -79,7 +79,13 @@ export interface BrainExecutionContext {
   topLevelStepCount: number;
 }
 
-export type ExecutionState = 'idle' | 'running' | 'paused' | 'complete' | 'error' | 'cancelled';
+export type ExecutionState =
+  | 'idle'
+  | 'running'
+  | 'paused'
+  | 'complete'
+  | 'error'
+  | 'cancelled';
 
 // Payload types for transitions
 export interface StartBrainPayload {
@@ -131,7 +137,9 @@ export interface CreateMachineOptions {
   events?: Array<{ type: string } & Record<string, unknown>>;
 }
 
-const createInitialContext = (opts?: CreateMachineOptions): BrainExecutionContext => ({
+const createInitialContext = (
+  opts?: CreateMachineOptions
+): BrainExecutionContext => ({
   brainStack: [],
   depth: 0,
   brainRunId: null,
@@ -156,7 +164,10 @@ const createInitialContext = (opts?: CreateMachineOptions): BrainExecutionContex
 // Helper to update derived state
 // ============================================================================
 
-const updateDerivedState = (ctx: BrainExecutionContext, executionState: ExecutionState): BrainExecutionContext => {
+const updateDerivedState = (
+  ctx: BrainExecutionContext,
+  executionState: ExecutionState
+): BrainExecutionContext => {
   // Map ExecutionState to STATUS - this gives consumers the authoritative status
   let status: (typeof STATUS)[keyof typeof STATUS];
   switch (executionState) {
@@ -199,63 +210,109 @@ const updateDerivedState = (ctx: BrainExecutionContext, executionState: Executio
 // Reducers - Update context on transitions
 // ============================================================================
 
-const startBrain = reduce<BrainExecutionContext, StartBrainPayload>((ctx, { brainRunId, brainTitle, brainDescription, initialState }) => {
-  const { currentStepId, brainStack, depth, brainRunId: existingBrainRunId, currentState, options } = ctx;
+const startBrain = reduce<BrainExecutionContext, StartBrainPayload>(
+  (ctx, { brainRunId, brainTitle, brainDescription, initialState }) => {
+    const {
+      currentStepId,
+      brainStack,
+      depth,
+      brainRunId: existingBrainRunId,
+      currentState,
+      options,
+    } = ctx;
 
-  const newEntry: BrainStackEntry = {
-    brainRunId,
-    brainTitle,
-    brainDescription,
-    parentStepId: currentStepId,
-    steps: [],
-  };
-
-  const newDepth = depth + 1;
-  const newCtx: BrainExecutionContext = {
-    ...ctx,
-    brainStack: [...brainStack, newEntry],
-    depth: newDepth,
-    brainRunId: existingBrainRunId ?? brainRunId,
-    currentState: newDepth === 1 ? (initialState ?? currentState) : currentState,
-    currentEvent: {
-      type: BRAIN_EVENTS.START,
+    const newEntry: BrainStackEntry = {
+      brainRunId,
       brainTitle,
       brainDescription,
-      brainRunId,
-      initialState: initialState ?? {},
-      status: STATUS.RUNNING,
+      parentStepId: currentStepId,
+      steps: [],
+    };
+
+    const newDepth = depth + 1;
+    const newCtx: BrainExecutionContext = {
+      ...ctx,
+      brainStack: [...brainStack, newEntry],
+      depth: newDepth,
+      brainRunId: existingBrainRunId ?? brainRunId,
+      currentState:
+        newDepth === 1 ? initialState ?? currentState : currentState,
+      currentEvent: {
+        type: BRAIN_EVENTS.START,
+        brainTitle,
+        brainDescription,
+        brainRunId,
+        initialState: initialState ?? {},
+        status: STATUS.RUNNING,
+        options,
+      },
+    };
+
+    return updateDerivedState(newCtx, 'running');
+  }
+);
+
+const restartBrain = reduce<BrainExecutionContext, StartBrainPayload>(
+  (ctx, { brainRunId, brainTitle, brainDescription, initialState }) => {
+    const {
+      currentStepId,
+      brainStack,
+      depth,
+      brainRunId: existingBrainRunId,
       options,
-    },
-  };
+    } = ctx;
 
-  return updateDerivedState(newCtx, 'running');
-});
+    // brain:restart can be either:
+    // 1. A resume of an existing brain on the stack (same brainTitle) - should REPLACE
+    // 2. A nested inner brain restarting (different brainTitle) - should ADD
+    if (brainStack.length > 0) {
+      const lastBrain = brainStack[brainStack.length - 1];
 
-const restartBrain = reduce<BrainExecutionContext, StartBrainPayload>((ctx, { brainRunId, brainTitle, brainDescription, initialState }) => {
-  const { currentStepId, brainStack, depth, brainRunId: existingBrainRunId, options } = ctx;
+      // If the last brain has the same title, this is a resume - replace it
+      if (lastBrain.brainTitle === brainTitle) {
+        const newEntry: BrainStackEntry = {
+          brainRunId,
+          brainTitle,
+          brainDescription,
+          parentStepId: lastBrain.parentStepId, // Keep original parentStepId
+          steps: [], // Steps will be populated by subsequent step:status events
+        };
 
-  // brain:restart can be either:
-  // 1. A resume of an existing brain on the stack (same brainTitle) - should REPLACE
-  // 2. A nested inner brain restarting (different brainTitle) - should ADD
-  if (brainStack.length > 0) {
-    const lastBrain = brainStack[brainStack.length - 1];
+        const newStack = [...brainStack.slice(0, -1), newEntry];
 
-    // If the last brain has the same title, this is a resume - replace it
-    if (lastBrain.brainTitle === brainTitle) {
+        const newCtx: BrainExecutionContext = {
+          ...ctx,
+          brainStack: newStack,
+          // depth stays the same - we're replacing, not nesting
+          brainRunId: existingBrainRunId ?? brainRunId,
+          currentEvent: {
+            type: BRAIN_EVENTS.RESTART,
+            brainTitle,
+            brainDescription,
+            brainRunId,
+            initialState: initialState ?? {},
+            status: STATUS.RUNNING,
+            options,
+          },
+        };
+
+        return updateDerivedState(newCtx, 'running');
+      }
+
+      // Different title - this is a nested inner brain restarting, ADD to stack
       const newEntry: BrainStackEntry = {
         brainRunId,
         brainTitle,
         brainDescription,
-        parentStepId: lastBrain.parentStepId, // Keep original parentStepId
-        steps: [], // Steps will be populated by subsequent step:status events
+        parentStepId: currentStepId,
+        steps: [],
       };
 
-      const newStack = [...brainStack.slice(0, -1), newEntry];
-
+      const newDepth = depth + 1;
       const newCtx: BrainExecutionContext = {
         ...ctx,
-        brainStack: newStack,
-        // depth stays the same - we're replacing, not nesting
+        brainStack: [...brainStack, newEntry],
+        depth: newDepth,
         brainRunId: existingBrainRunId ?? brainRunId,
         currentEvent: {
           type: BRAIN_EVENTS.RESTART,
@@ -271,20 +328,19 @@ const restartBrain = reduce<BrainExecutionContext, StartBrainPayload>((ctx, { br
       return updateDerivedState(newCtx, 'running');
     }
 
-    // Different title - this is a nested inner brain restarting, ADD to stack
+    // No brain on stack - this is a fresh restart from idle state
     const newEntry: BrainStackEntry = {
       brainRunId,
       brainTitle,
       brainDescription,
-      parentStepId: currentStepId,
+      parentStepId: null,
       steps: [],
     };
 
-    const newDepth = depth + 1;
     const newCtx: BrainExecutionContext = {
       ...ctx,
-      brainStack: [...brainStack, newEntry],
-      depth: newDepth,
+      brainStack: [newEntry],
+      depth: 1,
       brainRunId: existingBrainRunId ?? brainRunId,
       currentEvent: {
         type: BRAIN_EVENTS.RESTART,
@@ -299,34 +355,7 @@ const restartBrain = reduce<BrainExecutionContext, StartBrainPayload>((ctx, { br
 
     return updateDerivedState(newCtx, 'running');
   }
-
-  // No brain on stack - this is a fresh restart from idle state
-  const newEntry: BrainStackEntry = {
-    brainRunId,
-    brainTitle,
-    brainDescription,
-    parentStepId: null,
-    steps: [],
-  };
-
-  const newCtx: BrainExecutionContext = {
-    ...ctx,
-    brainStack: [newEntry],
-    depth: 1,
-    brainRunId: existingBrainRunId ?? brainRunId,
-    currentEvent: {
-      type: BRAIN_EVENTS.RESTART,
-      brainTitle,
-      brainDescription,
-      brainRunId,
-      initialState: initialState ?? {},
-      status: STATUS.RUNNING,
-      options,
-    },
-  };
-
-  return updateDerivedState(newCtx, 'running');
-});
+);
 
 const completeBrain = reduce<BrainExecutionContext, object>((ctx) => {
   const { brainStack, depth, brainRunId, options } = ctx;
@@ -339,7 +368,9 @@ const completeBrain = reduce<BrainExecutionContext, object>((ctx) => {
   // Attach completed brain's steps to parent step if nested
   if (newStack.length > 0 && completedBrain.parentStepId) {
     const parentBrain = newStack[newStack.length - 1];
-    const parentStep = parentBrain.steps.find((s) => s.id === completedBrain.parentStepId);
+    const parentStep = parentBrain.steps.find(
+      (s) => s.id === completedBrain.parentStepId
+    );
     if (parentStep) {
       parentStep.innerSteps = completedBrain.steps;
       parentStep.status = STATUS.COMPLETE;
@@ -366,26 +397,28 @@ const completeBrain = reduce<BrainExecutionContext, object>((ctx) => {
   return updateDerivedState(newCtx, isNowComplete ? 'complete' : 'running');
 });
 
-const errorBrain = reduce<BrainExecutionContext, ErrorPayload>((ctx, { error }) => {
-  const { brainStack, brainRunId, options } = ctx;
-  const currentBrain = brainStack[brainStack.length - 1];
+const errorBrain = reduce<BrainExecutionContext, ErrorPayload>(
+  (ctx, { error }) => {
+    const { brainStack, brainRunId, options } = ctx;
+    const currentBrain = brainStack[brainStack.length - 1];
 
-  const newCtx: BrainExecutionContext = {
-    ...ctx,
-    error,
-    currentEvent: {
-      type: BRAIN_EVENTS.ERROR,
-      brainTitle: currentBrain?.brainTitle,
-      brainDescription: currentBrain?.brainDescription,
-      brainRunId: brainRunId!,
+    const newCtx: BrainExecutionContext = {
+      ...ctx,
       error,
-      status: STATUS.ERROR,
-      options,
-    },
-  };
+      currentEvent: {
+        type: BRAIN_EVENTS.ERROR,
+        brainTitle: currentBrain?.brainTitle,
+        brainDescription: currentBrain?.brainDescription,
+        brainRunId: brainRunId!,
+        error,
+        status: STATUS.ERROR,
+        options,
+      },
+    };
 
-  return updateDerivedState(newCtx, 'error');
-});
+    return updateDerivedState(newCtx, 'error');
+  }
+);
 
 const cancelBrain = reduce<BrainExecutionContext, object>((ctx) => {
   const { brainStack, brainRunId, options } = ctx;
@@ -406,286 +439,337 @@ const cancelBrain = reduce<BrainExecutionContext, object>((ctx) => {
   return updateDerivedState(newCtx, 'cancelled');
 });
 
-const startStep = reduce<BrainExecutionContext, StartStepPayload>((ctx, { stepId, stepTitle }) => {
-  const { brainStack, brainRunId, options } = ctx;
+const startStep = reduce<BrainExecutionContext, StartStepPayload>(
+  (ctx, { stepId, stepTitle }) => {
+    const { brainStack, brainRunId, options } = ctx;
 
-  // Add step to current brain's steps if not already there
-  if (brainStack.length > 0) {
-    const currentBrain = brainStack[brainStack.length - 1];
-    const existingStep = currentBrain.steps.find((s) => s.id === stepId);
-    if (!existingStep) {
-      currentBrain.steps.push({
-        id: stepId,
-        title: stepTitle,
+    // Add step to current brain's steps if not already there
+    if (brainStack.length > 0) {
+      const currentBrain = brainStack[brainStack.length - 1];
+      const existingStep = currentBrain.steps.find((s) => s.id === stepId);
+      if (!existingStep) {
+        currentBrain.steps.push({
+          id: stepId,
+          title: stepTitle,
+          status: STATUS.RUNNING,
+        });
+      } else {
+        existingStep.status = STATUS.RUNNING;
+      }
+    }
+
+    return {
+      ...ctx,
+      currentStepId: stepId,
+      currentStepTitle: stepTitle,
+      currentEvent: {
+        type: BRAIN_EVENTS.STEP_START,
+        brainRunId: brainRunId!,
+        stepId,
+        stepTitle,
         status: STATUS.RUNNING,
-      });
-    } else {
-      existingStep.status = STATUS.RUNNING;
-    }
+        options,
+      },
+    };
   }
+);
 
-  return {
-    ...ctx,
-    currentStepId: stepId,
-    currentStepTitle: stepTitle,
-    currentEvent: {
-      type: BRAIN_EVENTS.STEP_START,
-      brainRunId: brainRunId!,
-      stepId,
-      stepTitle,
-      status: STATUS.RUNNING,
+const completeStep = reduce<BrainExecutionContext, CompleteStepPayload>(
+  (ctx, { stepId, stepTitle, patch }) => {
+    const {
+      brainStack,
+      depth,
+      currentState,
+      topLevelStepCount,
+      brainRunId,
       options,
-    },
-  };
-});
+    } = ctx;
 
-const completeStep = reduce<BrainExecutionContext, CompleteStepPayload>((ctx, { stepId, stepTitle, patch }) => {
-  const { brainStack, depth, currentState, topLevelStepCount, brainRunId, options } = ctx;
-
-  if (brainStack.length > 0) {
-    const currentBrain = brainStack[brainStack.length - 1];
-    const step = currentBrain.steps.find((s) => s.id === stepId);
-    if (step) {
-      step.status = STATUS.COMPLETE;
-      step.patch = patch;
+    if (brainStack.length > 0) {
+      const currentBrain = brainStack[brainStack.length - 1];
+      const step = currentBrain.steps.find((s) => s.id === stepId);
+      if (step) {
+        step.status = STATUS.COMPLETE;
+        step.patch = patch;
+      }
     }
-  }
 
-  // Apply patch to currentState only for top-level brain
-  let newState = currentState;
-  let newStepCount = topLevelStepCount;
-  if (depth === 1 && patch) {
-    newState = applyPatches(currentState, [patch]) as JsonObject;
-    newStepCount = topLevelStepCount + 1;
-  }
-
-  return {
-    ...ctx,
-    currentState: newState,
-    topLevelStepCount: newStepCount,
-    currentEvent: {
-      type: BRAIN_EVENTS.STEP_COMPLETE,
-      brainRunId: brainRunId!,
-      stepId,
-      stepTitle,
-      patch,
-      status: STATUS.RUNNING,
-      options,
-    },
-  };
-});
-
-const webhookPause = reduce<BrainExecutionContext, WebhookPayload>((ctx, { waitFor }) => {
-  const { brainRunId, options } = ctx;
-
-  const newCtx: BrainExecutionContext = {
-    ...ctx,
-    pendingWebhooks: waitFor,
-    currentEvent: {
-      type: BRAIN_EVENTS.WEBHOOK,
-      brainRunId: brainRunId!,
-      waitFor,
-      options,
-    },
-  };
-
-  return updateDerivedState(newCtx, 'paused');
-});
-
-const webhookResponse = reduce<BrainExecutionContext, { response: JsonObject }>((ctx, { response }) => {
-  const { brainRunId, options } = ctx;
-
-  const newCtx: BrainExecutionContext = {
-    ...ctx,
-    pendingWebhooks: null,
-    currentEvent: {
-      type: BRAIN_EVENTS.WEBHOOK_RESPONSE,
-      brainRunId: brainRunId!,
-      response,
-      options,
-    },
-  };
-
-  return updateDerivedState(newCtx, 'running');
-});
-
-const stepStatus = reduce<BrainExecutionContext, StepStatusPayload>((ctx, { brainRunId: eventBrainRunId, steps }) => {
-  const { brainRunId, brainStack, options } = ctx;
-
-  if (brainStack.length === 0) return ctx;
-
-  // Only update the current (deepest) brain on the stack.
-  // STEP_STATUS is emitted by the currently executing brain, which is always
-  // the deepest one. We can't match by brainRunId because nested brains share
-  // the same brainRunId, which would incorrectly update all nested brains.
-  const updatedStack = brainStack.map((brain, index) => {
-    if (index === brainStack.length - 1) {
-      // Create a map of existing steps to preserve their patches
-      const existingStepsById = new Map(brain.steps.map(s => [s.id, s]));
-
-      return {
-        ...brain,
-        steps: steps.map(s => {
-          const existing = existingStepsById.get(s.id);
-          return {
-            id: s.id,
-            title: s.title,
-            status: s.status as StepInfo['status'],
-            // Preserve existing patch if we have one
-            ...(existing?.patch ? { patch: existing.patch } : {}),
-          };
-        }),
-      };
+    // Apply patch to currentState only for top-level brain
+    let newState = currentState;
+    let newStepCount = topLevelStepCount;
+    if (depth === 1 && patch) {
+      newState = applyPatches(currentState, [patch]) as JsonObject;
+      newStepCount = topLevelStepCount + 1;
     }
-    return brain;
+
+    return {
+      ...ctx,
+      currentState: newState,
+      topLevelStepCount: newStepCount,
+      currentEvent: {
+        type: BRAIN_EVENTS.STEP_COMPLETE,
+        brainRunId: brainRunId!,
+        stepId,
+        stepTitle,
+        patch,
+        status: STATUS.RUNNING,
+        options,
+      },
+    };
+  }
+);
+
+const webhookPause = reduce<BrainExecutionContext, WebhookPayload>(
+  (ctx, { waitFor }) => {
+    const { brainRunId, options } = ctx;
+
+    const newCtx: BrainExecutionContext = {
+      ...ctx,
+      pendingWebhooks: waitFor,
+      currentEvent: {
+        type: BRAIN_EVENTS.WEBHOOK,
+        brainRunId: brainRunId!,
+        waitFor,
+        options,
+      },
+    };
+
+    return updateDerivedState(newCtx, 'paused');
+  }
+);
+
+const webhookResponse = reduce<BrainExecutionContext, { response: JsonObject }>(
+  (ctx, { response }) => {
+    const { brainRunId, options } = ctx;
+
+    const newCtx: BrainExecutionContext = {
+      ...ctx,
+      pendingWebhooks: null,
+      currentEvent: {
+        type: BRAIN_EVENTS.WEBHOOK_RESPONSE,
+        brainRunId: brainRunId!,
+        response,
+        options,
+      },
+    };
+
+    return updateDerivedState(newCtx, 'running');
+  }
+);
+
+const stepStatus = reduce<BrainExecutionContext, StepStatusPayload>(
+  (ctx, { brainRunId: eventBrainRunId, steps }) => {
+    const { brainRunId, brainStack, options } = ctx;
+
+    if (brainStack.length === 0) return ctx;
+
+    // Only update the current (deepest) brain on the stack.
+    // STEP_STATUS is emitted by the currently executing brain, which is always
+    // the deepest one. We can't match by brainRunId because nested brains share
+    // the same brainRunId, which would incorrectly update all nested brains.
+    const updatedStack = brainStack.map((brain, index) => {
+      if (index === brainStack.length - 1) {
+        // Create a map of existing steps to preserve their patches
+        const existingStepsById = new Map(brain.steps.map((s) => [s.id, s]));
+
+        return {
+          ...brain,
+          steps: steps.map((s) => {
+            const existing = existingStepsById.get(s.id);
+            return {
+              id: s.id,
+              title: s.title,
+              status: s.status as StepInfo['status'],
+              // Preserve existing patch if we have one
+              ...(existing?.patch ? { patch: existing.patch } : {}),
+            };
+          }),
+        };
+      }
+      return brain;
+    });
+
+    return {
+      ...ctx,
+      brainStack: updatedStack,
+      currentEvent: {
+        type: BRAIN_EVENTS.STEP_STATUS,
+        brainRunId: brainRunId!,
+        steps,
+        options,
+      },
+    };
+  }
+);
+
+const stepRetry = reduce<BrainExecutionContext, StepRetryPayload>(
+  (ctx, { stepId, stepTitle, error, attempt }) => {
+    const { brainRunId, options } = ctx;
+
+    return {
+      ...ctx,
+      currentEvent: {
+        type: BRAIN_EVENTS.STEP_RETRY,
+        brainRunId: brainRunId!,
+        stepId,
+        stepTitle,
+        error,
+        attempt,
+        options,
+      },
+    };
+  }
+);
+
+const passthrough = (eventType: string) =>
+  reduce<BrainExecutionContext, any>((ctx, ev) => {
+    const { brainRunId, options } = ctx;
+    // Destructure to exclude 'type' (the action name) from being spread into currentEvent
+    const { type: _actionType, ...eventData } = ev;
+
+    return {
+      ...ctx,
+      currentEvent: {
+        type: eventType,
+        brainRunId: brainRunId!,
+        options,
+        ...eventData,
+      },
+    };
   });
-
-  return {
-    ...ctx,
-    brainStack: updatedStack,
-    currentEvent: {
-      type: BRAIN_EVENTS.STEP_STATUS,
-      brainRunId: brainRunId!,
-      steps,
-      options,
-    },
-  };
-});
-
-const stepRetry = reduce<BrainExecutionContext, StepRetryPayload>((ctx, { stepId, stepTitle, error, attempt }) => {
-  const { brainRunId, options } = ctx;
-
-  return {
-    ...ctx,
-    currentEvent: {
-      type: BRAIN_EVENTS.STEP_RETRY,
-      brainRunId: brainRunId!,
-      stepId,
-      stepTitle,
-      error,
-      attempt,
-      options,
-    },
-  };
-});
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const passthrough = (eventType: string) => reduce<BrainExecutionContext, any>((ctx, ev) => {
-  const { brainRunId, options } = ctx;
-  // Destructure to exclude 'type' (the action name) from being spread into currentEvent
-  const { type: _actionType, ...eventData } = ev;
-
-  return {
-    ...ctx,
-    currentEvent: {
-      type: eventType,
-      brainRunId: brainRunId!,
-      options,
-      ...eventData,
-    },
-  };
-});
 
 // ============================================================================
 // Guards - Conditional transitions
 // ============================================================================
 
-const isOuterBrain = guard<BrainExecutionContext, object>((ctx) => ctx.depth === 1);
-const isInnerBrain = guard<BrainExecutionContext, object>((ctx) => ctx.depth > 1);
+const isOuterBrain = guard<BrainExecutionContext, object>(
+  (ctx) => ctx.depth === 1
+);
+const isInnerBrain = guard<BrainExecutionContext, object>(
+  (ctx) => ctx.depth > 1
+);
 
 // ============================================================================
 // State Machine Definition
 // ============================================================================
 
-// Action names for transitions
-const ACTIONS = {
-  START_BRAIN: 'startBrain',
-  RESTART_BRAIN: 'restartBrain',
-  COMPLETE_BRAIN: 'completeBrain',
-  ERROR_BRAIN: 'errorBrain',
-  CANCEL_BRAIN: 'cancelBrain',
-  WEBHOOK: 'webhook',
-  WEBHOOK_RESPONSE: 'webhookResponse',
-  START_STEP: 'startStep',
-  COMPLETE_STEP: 'completeStep',
-  STEP_STATUS: 'stepStatus',
-  STEP_RETRY: 'stepRetry',
-  LOOP_START: 'loopStart',
-  LOOP_ITERATION: 'loopIteration',
-  LOOP_TOOL_CALL: 'loopToolCall',
-  LOOP_TOOL_RESULT: 'loopToolResult',
-  LOOP_ASSISTANT_MESSAGE: 'loopAssistantMessage',
-  LOOP_COMPLETE: 'loopComplete',
-  LOOP_TOKEN_LIMIT: 'loopTokenLimit',
-  LOOP_WEBHOOK: 'loopWebhook',
-  HEARTBEAT: 'heartbeat',
-} as const;
-
-export { ACTIONS as BRAIN_ACTIONS };
-
 // Create machine factory - needs to be called with initial context
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createBrainMachine = (initialContext: BrainExecutionContext): any =>
+const createBrainMachine = (initialContext: BrainExecutionContext) =>
   createMachine(
     'idle',
     {
       idle: state(
-        transition(ACTIONS.START_BRAIN, 'running', startBrain),
-        transition(ACTIONS.RESTART_BRAIN, 'running', restartBrain) as any
+        transition(BRAIN_EVENTS.START, 'running', startBrain),
+        transition(BRAIN_EVENTS.RESTART, 'running', restartBrain) as any
       ),
 
       running: state(
         // Nested brain lifecycle
-        transition(ACTIONS.START_BRAIN, 'running', startBrain),
-        transition(ACTIONS.RESTART_BRAIN, 'running', restartBrain) as any,
+        transition(BRAIN_EVENTS.START, 'running', startBrain),
+        transition(BRAIN_EVENTS.RESTART, 'running', restartBrain) as any,
 
         // Outer brain complete -> terminal
-        transition(ACTIONS.COMPLETE_BRAIN, 'complete', isOuterBrain, completeBrain) as any,
+        transition(
+          BRAIN_EVENTS.COMPLETE,
+          'complete',
+          isOuterBrain,
+          completeBrain
+        ) as any,
         // Inner brain complete -> stay running
-        transition(ACTIONS.COMPLETE_BRAIN, 'running', isInnerBrain, completeBrain) as any,
+        transition(
+          BRAIN_EVENTS.COMPLETE,
+          'running',
+          isInnerBrain,
+          completeBrain
+        ) as any,
 
         // Error (only outer brain errors are terminal)
-        transition(ACTIONS.ERROR_BRAIN, 'error', isOuterBrain, errorBrain) as any,
+        transition(
+          BRAIN_EVENTS.ERROR,
+          'error',
+          isOuterBrain,
+          errorBrain
+        ) as any,
 
         // Cancelled
-        transition(ACTIONS.CANCEL_BRAIN, 'cancelled', cancelBrain) as any,
+        transition(BRAIN_EVENTS.CANCELLED, 'cancelled', cancelBrain) as any,
 
         // Webhook -> paused
-        transition(ACTIONS.WEBHOOK, 'paused', webhookPause) as any,
+        transition(BRAIN_EVENTS.WEBHOOK, 'paused', webhookPause) as any,
 
         // Webhook response (for resume from webhook - machine is already running)
-        transition(ACTIONS.WEBHOOK_RESPONSE, 'running', webhookResponse) as any,
+        transition(
+          BRAIN_EVENTS.WEBHOOK_RESPONSE,
+          'running',
+          webhookResponse
+        ) as any,
 
         // Step events
-        transition(ACTIONS.START_STEP, 'running', startStep) as any,
-        transition(ACTIONS.COMPLETE_STEP, 'running', completeStep) as any,
-        transition(ACTIONS.STEP_STATUS, 'running', stepStatus) as any,
-        transition(ACTIONS.STEP_RETRY, 'running', stepRetry) as any,
+        transition(BRAIN_EVENTS.STEP_START, 'running', startStep) as any,
+        transition(BRAIN_EVENTS.STEP_COMPLETE, 'running', completeStep) as any,
+        transition(BRAIN_EVENTS.STEP_STATUS, 'running', stepStatus) as any,
+        transition(BRAIN_EVENTS.STEP_RETRY, 'running', stepRetry) as any,
 
         // Loop events (pass-through with event data)
-        transition(ACTIONS.LOOP_START, 'running', passthrough(BRAIN_EVENTS.LOOP_START)) as any,
-        transition(ACTIONS.LOOP_ITERATION, 'running', passthrough(BRAIN_EVENTS.LOOP_ITERATION)) as any,
-        transition(ACTIONS.LOOP_TOOL_CALL, 'running', passthrough(BRAIN_EVENTS.LOOP_TOOL_CALL)) as any,
-        transition(ACTIONS.LOOP_TOOL_RESULT, 'running', passthrough(BRAIN_EVENTS.LOOP_TOOL_RESULT)) as any,
-        transition(ACTIONS.LOOP_ASSISTANT_MESSAGE, 'running', passthrough(BRAIN_EVENTS.LOOP_ASSISTANT_MESSAGE)) as any,
-        transition(ACTIONS.LOOP_COMPLETE, 'running', passthrough(BRAIN_EVENTS.LOOP_COMPLETE)) as any,
-        transition(ACTIONS.LOOP_TOKEN_LIMIT, 'running', passthrough(BRAIN_EVENTS.LOOP_TOKEN_LIMIT)) as any,
-        transition(ACTIONS.LOOP_WEBHOOK, 'running', passthrough(BRAIN_EVENTS.LOOP_WEBHOOK)) as any,
-        transition(ACTIONS.HEARTBEAT, 'running', passthrough(BRAIN_EVENTS.HEARTBEAT)) as any
+        transition(
+          BRAIN_EVENTS.LOOP_START,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_START)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_ITERATION,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_ITERATION)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_TOOL_CALL,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_TOOL_CALL)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_TOOL_RESULT,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_TOOL_RESULT)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_ASSISTANT_MESSAGE,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_ASSISTANT_MESSAGE)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_COMPLETE,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_COMPLETE)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_TOKEN_LIMIT,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_TOKEN_LIMIT)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.LOOP_WEBHOOK,
+          'running',
+          passthrough(BRAIN_EVENTS.LOOP_WEBHOOK)
+        ) as any,
+        transition(
+          BRAIN_EVENTS.HEARTBEAT,
+          'running',
+          passthrough(BRAIN_EVENTS.HEARTBEAT)
+        ) as any
       ),
 
       paused: state(
-        transition(ACTIONS.WEBHOOK_RESPONSE, 'running', webhookResponse),
-        transition(ACTIONS.CANCEL_BRAIN, 'cancelled', cancelBrain) as any,
+        transition(BRAIN_EVENTS.WEBHOOK_RESPONSE, 'running', webhookResponse),
+        transition(BRAIN_EVENTS.CANCELLED, 'cancelled', cancelBrain) as any,
         // RESTART happens when resuming from webhook
-        transition(ACTIONS.RESTART_BRAIN, 'running', restartBrain) as any
+        transition(BRAIN_EVENTS.RESTART, 'running', restartBrain) as any
       ),
 
       // Terminal states - limited outgoing transitions
       complete: state(),
       error: state(
         // Allow STEP_STATUS after error so we can emit the final step statuses
-        transition(ACTIONS.STEP_STATUS, 'error', stepStatus) as any
+        transition(BRAIN_EVENTS.STEP_STATUS, 'error', stepStatus) as any
       ),
       cancelled: state(),
     },
@@ -703,111 +787,21 @@ export interface BrainStateMachine {
   send: (event: { type: string; [key: string]: unknown }) => void;
 }
 
-// Event type to action mapping
-const EVENT_TO_ACTION: Record<string, string> = {
-  [BRAIN_EVENTS.START]: ACTIONS.START_BRAIN,
-  [BRAIN_EVENTS.RESTART]: ACTIONS.RESTART_BRAIN,
-  [BRAIN_EVENTS.COMPLETE]: ACTIONS.COMPLETE_BRAIN,
-  [BRAIN_EVENTS.ERROR]: ACTIONS.ERROR_BRAIN,
-  [BRAIN_EVENTS.CANCELLED]: ACTIONS.CANCEL_BRAIN,
-  [BRAIN_EVENTS.WEBHOOK]: ACTIONS.WEBHOOK,
-  [BRAIN_EVENTS.WEBHOOK_RESPONSE]: ACTIONS.WEBHOOK_RESPONSE,
-  [BRAIN_EVENTS.STEP_START]: ACTIONS.START_STEP,
-  [BRAIN_EVENTS.STEP_COMPLETE]: ACTIONS.COMPLETE_STEP,
-  [BRAIN_EVENTS.STEP_STATUS]: ACTIONS.STEP_STATUS,
-  [BRAIN_EVENTS.STEP_RETRY]: ACTIONS.STEP_RETRY,
-  [BRAIN_EVENTS.LOOP_START]: ACTIONS.LOOP_START,
-  [BRAIN_EVENTS.LOOP_ITERATION]: ACTIONS.LOOP_ITERATION,
-  [BRAIN_EVENTS.LOOP_TOOL_CALL]: ACTIONS.LOOP_TOOL_CALL,
-  [BRAIN_EVENTS.LOOP_TOOL_RESULT]: ACTIONS.LOOP_TOOL_RESULT,
-  [BRAIN_EVENTS.LOOP_ASSISTANT_MESSAGE]: ACTIONS.LOOP_ASSISTANT_MESSAGE,
-  [BRAIN_EVENTS.LOOP_COMPLETE]: ACTIONS.LOOP_COMPLETE,
-  [BRAIN_EVENTS.LOOP_TOKEN_LIMIT]: ACTIONS.LOOP_TOKEN_LIMIT,
-  [BRAIN_EVENTS.LOOP_WEBHOOK]: ACTIONS.LOOP_WEBHOOK,
-  [BRAIN_EVENTS.HEARTBEAT]: ACTIONS.HEARTBEAT,
-};
-
-/**
- * Extract relevant payload fields from a brain event for the state machine.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractPayloadFromEvent(event: { type: string } & Record<string, any>): object {
-  switch (event.type) {
-    case BRAIN_EVENTS.START:
-    case BRAIN_EVENTS.RESTART:
-      return {
-        brainRunId: event.brainRunId,
-        brainTitle: event.brainTitle,
-        brainDescription: event.brainDescription,
-        initialState: event.initialState,
-      };
-    case BRAIN_EVENTS.STEP_START:
-      return {
-        stepId: event.stepId,
-        stepTitle: event.stepTitle,
-      };
-    case BRAIN_EVENTS.STEP_COMPLETE:
-      return {
-        stepId: event.stepId,
-        stepTitle: event.stepTitle,
-        patch: event.patch,
-      };
-    case BRAIN_EVENTS.ERROR:
-      return {
-        error: event.error,
-      };
-    case BRAIN_EVENTS.WEBHOOK:
-      return {
-        waitFor: event.waitFor,
-      };
-    case BRAIN_EVENTS.WEBHOOK_RESPONSE:
-      return {
-        response: event.response,
-      };
-    case BRAIN_EVENTS.STEP_STATUS:
-      return {
-        brainRunId: event.brainRunId,
-        steps: event.steps,
-      };
-    case BRAIN_EVENTS.STEP_RETRY:
-      return {
-        stepId: event.stepId,
-        stepTitle: event.stepTitle,
-        error: event.error,
-        attempt: event.attempt,
-      };
-    default:
-      // For pass-through events, pass all properties except type
-      const { type, ...rest } = event;
-      return rest;
-  }
-}
-
-/**
- * Replay a single event into the machine.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function replayEventToMachine(machine: BrainStateMachine, event: { type: string } & Record<string, any>): void {
-  const action = EVENT_TO_ACTION[event.type];
-  if (action) {
-    const payload = extractPayloadFromEvent(event);
-    machine.send({ type: action, ...payload });
-  }
-}
-
 /**
  * Create a new brain execution state machine.
  * Optionally replay events to restore state from history.
  */
-export function createBrainExecutionMachine(options?: CreateMachineOptions): BrainStateMachine {
+export function createBrainExecutionMachine(
+  options?: CreateMachineOptions
+): BrainStateMachine {
   const initialContext = createInitialContext(options);
   const machine = createBrainMachine(initialContext);
   const service = interpret(machine, () => {});
 
-  // Replay events if provided
+  // Replay events if provided - just send each event directly to the machine
   if (options?.events) {
     for (const event of options.events) {
-      replayEventToMachine(service, event);
+      service.send(event);
     }
   }
 
@@ -815,24 +809,14 @@ export function createBrainExecutionMachine(options?: CreateMachineOptions): Bra
 }
 
 /**
- * Send a transition action to the machine.
- * After calling this, read machine.context.currentEvent to get the event to yield.
+ * Send an event to the machine.
+ * The machine transitions use BRAIN_EVENTS types directly, so just pass the event through.
  */
-export function sendAction(
+export function sendEvent(
   machine: BrainStateMachine,
-  action: string,
-  payload?: object
+  event: { type: string } & Record<string, any>
 ): void {
-  machine.send({ type: action, ...payload });
-}
-
-/**
- * Feed an incoming event into the machine to update state (observer mode).
- * Maps brain event types to machine actions.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function sendEvent(machine: BrainStateMachine, event: { type: string } & Record<string, any>): void {
-  replayEventToMachine(machine, event);
+  machine.send(event);
 }
 
 // ============================================================================
@@ -868,7 +852,9 @@ export function getExecutionState(machine: BrainStateMachine): ExecutionState {
   return machine.machine.current as ExecutionState;
 }
 
-export function getPendingWebhooks(machine: BrainStateMachine): WebhookRegistration[] | null {
+export function getPendingWebhooks(
+  machine: BrainStateMachine
+): WebhookRegistration[] | null {
   return machine.context.pendingWebhooks;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,7 +69,6 @@ export { reconstructLoopContext } from './dsl/loop-messages.js';
 // Brain state machine
 export {
   createBrainExecutionMachine,
-  sendAction,
   sendEvent,
   getDepth,
   isTopLevel,
@@ -80,7 +79,6 @@ export {
   getPendingWebhooks,
   getError,
   getCompletedSteps,
-  BRAIN_ACTIONS,
 } from './dsl/brain-state-machine.js';
 export type {
   BrainStateMachine,

--- a/packages/core/tests/brain-state-machine.test.ts
+++ b/packages/core/tests/brain-state-machine.test.ts
@@ -1,8 +1,6 @@
 import {
   createBrainExecutionMachine,
   sendEvent,
-  BRAIN_ACTIONS,
-  sendAction,
 } from '../src/dsl/brain-state-machine.js';
 import { BRAIN_EVENTS, STATUS } from '../src/dsl/constants.js';
 


### PR DESCRIPTION
## Summary

- Fixed bug where MonitorDO showed outer brain status as "complete" when inner brain completed
- MonitorDO now stores events and replays them through the brain state machine
- Added `status` field to `BrainExecutionContext` so consumers don't need to interpret depth
- Added spec test to verify the fix

## Problem

When an inner brain completed during nested brain execution, MonitorDO incorrectly showed the outer brain's status as "complete" even though it was still running. This happened because:

1. Inner brain emits `COMPLETE` event
2. MonitorDO was duplicating the state machine's depth/status logic
3. The duplicated logic had a bug with `RESTART` events

## Solution

MonitorDO now:
1. Stores each lifecycle event in a `brain_events` table (append-only)
2. Replays all events through a fresh state machine on each new event
3. Uses `machine.context.status` as the single source of truth

This eliminates the duplicated logic and ensures MonitorDO always has the correct depth-aware status.

## Test plan

- [x] New spec test `innerBrainCompleteDoesNotAffectOuterStatus` passes
- [x] All 107 cloudflare tests pass
- [x] All 257 other tests pass
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)