### PR TITLE
Accept brain name or run ID in watch command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,6 +7117,19 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-robot": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-robot/-/react-robot-1.2.1.tgz",
+      "integrity": "sha512-FGX25Z1VFLxB05uFLRqg+MUqtcv1ZiugNjdIu35EYcJ0zDoc40H6yKi4VrEq+v49YTAa14khgTzRb+IM8YG/LA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "robot-hooks": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18.2.0 || ^19.0.0",
+        "robot3": "^1.0.0"
+      }
+    },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -7270,6 +7283,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robot-hooks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/robot-hooks/-/robot-hooks-1.1.0.tgz",
+      "integrity": "sha512-42LgnUjW0gL0CZw9v9GJz+JtjAG4L+IluuhlA0jRgmYH1L+JqcyKKRQ4RSrZgyFJcStOYPKSqd5GneCDkdzZhw==",
+      "license": "BSD-2-Clause",
+      "peerDependencies": {
+        "robot3": "^1.0.2"
       }
     },
     "node_modules/robot3": {
@@ -8422,6 +8444,7 @@
         "istextorbinary": "^9.5.0",
         "node-fetch": "^3.3.2",
         "react": "^18.3.1",
+        "react-robot": "^1.2.1",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "istextorbinary": "^9.5.0",
     "node-fetch": "^3.3.2",
     "react": "^18.3.1",
+    "react-robot": "^1.2.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -438,42 +438,27 @@ export function buildCli(options: CliOptions) {
 
   // --- Watch Brain Run Command ---
   cli = cli.command(
-    'watch [brain]',
-    'Watch a brain run: latest by brain name (default) or specific by ID\n',
+    'watch <identifier>',
+    'Watch a brain run by brain name or run ID\n',
     (yargsWatch) => {
       return yargsWatch
-        .positional('brain', {
-          describe: 'Brain identifier to watch (watches the most recent active run)',
+        .positional('identifier', {
+          describe: 'Brain name or run ID to watch',
           type: 'string',
-        })
-        .option('run-id', {
-          describe: 'ID of the specific brain run to watch',
-          type: 'string',
-          alias: 'id',
-        })
-        .conflicts('brain', 'run-id')
-        .check((argv) => {
-          if (!argv.brain && !argv.runId) {
-            throw new Error(
-              'You must provide either a brain identifier or a --run-id.'
-            );
-          }
-          return true;
+          demandOption: true,
         })
         .example(
           '$0 watch my-brain',
           "Watch the latest run of the brain named 'my-brain'"
         )
         .example(
-          '$0 watch --run-id abc123def',
+          '$0 watch abc123def',
           'Watch a specific brain run by its ID'
         );
     },
-    async (argv) => {
-      const element = await brainCommand.watch(argv);
-      if (element) {
-        render(element);
-      }
+    (argv) => {
+      const element = brainCommand.watch(argv);
+      render(element);
     }
   );
 
@@ -651,42 +636,27 @@ export function buildCli(options: CliOptions) {
         }
       )
       .command(
-        'watch [brain]',
-        'Watch a brain run: latest by brain name (default) or specific by ID\n',
+        'watch <identifier>',
+        'Watch a brain run by brain name or run ID\n',
         (yargsWatch) => {
           return yargsWatch
-            .positional('brain', {
-              describe: 'Brain identifier to watch (watches the most recent active run)',
+            .positional('identifier', {
+              describe: 'Brain name or run ID to watch',
               type: 'string',
-            })
-            .option('run-id', {
-              describe: 'ID of the specific brain run to watch',
-              type: 'string',
-              alias: 'id',
-            })
-            .conflicts('brain', 'run-id')
-            .check((argv) => {
-              if (!argv.brain && !argv.runId) {
-                throw new Error(
-                  'You must provide either a brain identifier or a --run-id.'
-                );
-              }
-              return true;
+              demandOption: true,
             })
             .example(
               '$0 brain watch my-brain',
               "Watch the latest run of the brain named 'my-brain'"
             )
             .example(
-              '$0 brain watch --run-id abc123def',
+              '$0 brain watch abc123def',
               'Watch a specific brain run by its ID'
             );
         },
-        async (argv) => {
-          const element = await brainCommand.watch(argv);
-          if (element) {
-            render(element);
-          }
+        (argv) => {
+          const element = brainCommand.watch(argv);
+          render(element);
         }
       )
       .command(

--- a/packages/cli/src/commands/brain.ts
+++ b/packages/cli/src/commands/brain.ts
@@ -1,6 +1,5 @@
 import type { ArgumentsCamelCase } from 'yargs';
 import React from 'react';
-import { Watch } from '../components/watch.js';
 import { BrainList } from '../components/brain-list.js';
 import { BrainHistory } from '../components/brain-history.js';
 import { RunShow } from '../components/run-show.js';
@@ -9,7 +8,7 @@ import { BrainRerun } from '../components/brain-rerun.js';
 import { BrainKill } from '../components/brain-kill.js';
 import { BrainRun } from '../components/brain-run.js';
 import { BrainResolver } from '../components/brain-resolver.js';
-import { BrainWatchWithResolver } from '../components/brain-watch.js';
+import { WatchResolver } from '../components/watch-resolver.js';
 import { BrainTop } from '../components/brain-top.js';
 import { ErrorComponent } from '../components/error.js';
 
@@ -35,8 +34,7 @@ interface BrainRunArgs {
   options?: Record<string, string>;
 }
 interface BrainWatchArgs {
-  runId?: string;
-  brain?: string;
+  identifier: string;
 }
 interface BrainKillArgs {
   runId: string;
@@ -114,31 +112,9 @@ export class BrainCommand {
   }
 
   watch({
-    runId,
-    brain,
+    identifier,
   }: ArgumentsCamelCase<BrainWatchArgs>): React.ReactElement {
-    // If a specific run ID is provided, return the Watch component
-    if (runId) {
-      return React.createElement(Watch, { runId });
-    }
-
-    // If watching by brain identifier is requested, use BrainWatchWithResolver
-    // which handles fuzzy search, disambiguation, and active run lookup
-    if (brain) {
-      return React.createElement(BrainWatchWithResolver, { identifier: brain });
-    }
-
-    // Neither runId nor brainName provided – return an error element.
-    return React.createElement(
-      ErrorComponent,
-      {
-        error: {
-          title: 'Missing Argument',
-          message: 'You must provide either a brain run ID or a brain identifier.',
-          details: 'Use --run-id to watch a specific run, or --brain to watch the active run of a brain.',
-        },
-      }
-    );
+    return React.createElement(WatchResolver, { identifier });
   }
 
   kill({

--- a/packages/cli/src/components/brain-rerun.tsx
+++ b/packages/cli/src/components/brain-rerun.tsx
@@ -89,7 +89,7 @@ export const BrainRerun = ({ identifier, runId, startsAt, stopsAfter }: BrainRer
           </Text>
           <Box marginTop={1}>
             <Text dimColor>
-              Watch the run with: positronic watch --run-id {newRunId}
+              Watch the run with: positronic watch {newRunId}
             </Text>
           </Box>
         </>

--- a/packages/cli/src/components/watch-resolver.tsx
+++ b/packages/cli/src/components/watch-resolver.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
+import * as robot3 from 'robot3';
 import { Watch } from './watch.js';
 import { ErrorComponent } from './error.js';
 import { apiClient, isApiLocalDevMode } from '../commands/helpers.js';
-import { STATUS } from '@positronic/core';
 
+const { createMachine, state, transition, reduce, interpret } = robot3;
+
+// Types
 interface Brain {
   title: string;
   description: string;
@@ -30,299 +33,392 @@ interface BrainRun {
   status: string;
 }
 
+interface ErrorInfo {
+  title: string;
+  message: string;
+  details?: string;
+}
+
+// State machine context
+interface ResolverContext {
+  identifier: string;
+  brains: Brain[];
+  selectedIndex: number;
+  resolvedBrainTitle: string | null;
+  resolvedRunId: string | null;
+  activeRuns: ActiveRunsResponse['runs'];
+  error: ErrorInfo | null;
+}
+
+// Events
+const EVENTS = {
+  BRAIN_FOUND: 'BRAIN_FOUND',
+  BRAIN_NOT_FOUND: 'BRAIN_NOT_FOUND',
+  BRAINS_MULTIPLE: 'BRAINS_MULTIPLE',
+  RUN_FOUND: 'RUN_FOUND',
+  NOT_FOUND: 'NOT_FOUND',
+  BRAIN_SELECTED: 'BRAIN_SELECTED',
+  ACTIVE_RUN_FOUND: 'ACTIVE_RUN_FOUND',
+  NO_ACTIVE_RUNS: 'NO_ACTIVE_RUNS',
+  MULTIPLE_ACTIVE_RUNS: 'MULTIPLE_ACTIVE_RUNS',
+  ERROR: 'ERROR',
+} as const;
+
+// Reducers - using object destructuring as requested
+const setBrainTitle = reduce<ResolverContext, { brainTitle: string }>(
+  (ctx, { brainTitle }) => ({ ...ctx, resolvedBrainTitle: brainTitle })
+);
+
+const setBrains = reduce<ResolverContext, { brains: Brain[] }>(
+  (ctx, { brains }) => ({ ...ctx, brains, selectedIndex: 0 })
+);
+
+const setRunId = reduce<ResolverContext, { runId: string }>(
+  (ctx, { runId }) => ({ ...ctx, resolvedRunId: runId })
+);
+
+const setActiveRuns = reduce<ResolverContext, { runs: ActiveRunsResponse['runs'] }>(
+  (ctx, { runs }) => ({ ...ctx, activeRuns: runs })
+);
+
+const setError = reduce<ResolverContext, { error: ErrorInfo }>(
+  (ctx, { error }) => ({ ...ctx, error })
+);
+
+// State machine definition - states and transitions are explicit
+// Note: Using `as any` to work around robot3's strict transition typing
+const createResolverMachine = (identifier: string) =>
+  createMachine(
+    'searchingBrain',
+    {
+      searchingBrain: state(
+        transition(EVENTS.BRAIN_FOUND, 'fetchingActiveRuns', setBrainTitle),
+        transition(EVENTS.BRAIN_NOT_FOUND, 'searchingRun') as any,
+        transition(EVENTS.BRAINS_MULTIPLE, 'disambiguating', setBrains) as any,
+        transition(EVENTS.ERROR, 'error', setError) as any
+      ),
+
+      searchingRun: state(
+        transition(EVENTS.RUN_FOUND, 'resolved', setRunId),
+        transition(EVENTS.NOT_FOUND, 'error', setError) as any,
+        transition(EVENTS.ERROR, 'error', setError) as any
+      ),
+
+      disambiguating: state(
+        transition(EVENTS.BRAIN_SELECTED, 'fetchingActiveRuns', setBrainTitle)
+      ),
+
+      fetchingActiveRuns: state(
+        transition(EVENTS.ACTIVE_RUN_FOUND, 'resolved', setRunId),
+        transition(EVENTS.NO_ACTIVE_RUNS, 'noActiveRuns') as any,
+        transition(EVENTS.MULTIPLE_ACTIVE_RUNS, 'multipleActiveRuns', setActiveRuns) as any,
+        transition(EVENTS.ERROR, 'error', setError) as any
+      ),
+
+      resolved: state(),
+      noActiveRuns: state(),
+      multipleActiveRuns: state(),
+      error: state(),
+    },
+    () => ({
+      identifier,
+      brains: [],
+      selectedIndex: 0,
+      resolvedBrainTitle: null,
+      resolvedRunId: null,
+      activeRuns: [],
+      error: null,
+    })
+  );
+
+// Helper to get connection error message
+const getConnectionError = (): ErrorInfo => {
+  if (isApiLocalDevMode()) {
+    return {
+      title: 'Connection Error',
+      message: 'Error connecting to the local development server.',
+      details: "Please ensure the server is running ('positronic server' or 'px s').",
+    };
+  }
+  return {
+    title: 'Connection Error',
+    message: 'Error connecting to the remote project server.',
+    details: 'Please check your network connection and verify the project URL is correct.',
+  };
+};
+
 interface WatchResolverProps {
   identifier: string;
 }
 
-type Phase =
-  | 'searching-brain'
-  | 'searching-run'
-  | 'disambiguating'
-  | 'fetching-active-runs'
-  | 'resolved-run'
-  | 'no-active-runs'
-  | 'multiple-active-runs'
-  | 'error';
-
 /**
  * WatchResolver - Resolves an identifier to either a brain name or run ID and starts watching.
  *
+ * State machine handles state/transitions, useEffect triggers async operations.
  * Resolution order:
  * 1. Try to resolve as a brain name (fuzzy search)
  * 2. If no brain matches, try as a run ID
  * 3. If neither works, show an error
- *
- * If resolved as a brain, looks up active runs and watches the appropriate one.
  */
 export const WatchResolver = ({ identifier }: WatchResolverProps) => {
-  const [phase, setPhase] = useState<Phase>('searching-brain');
-  const [brains, setBrains] = useState<Brain[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [resolvedRunId, setResolvedRunId] = useState<string | null>(null);
-  const [resolvedBrainTitle, setResolvedBrainTitle] = useState<string | null>(null);
-  const [activeRuns, setActiveRuns] = useState<ActiveRunsResponse['runs']>([]);
-  const [error, setError] = useState<{
-    title: string;
-    message: string;
-    details?: string;
-  } | null>(null);
+  const serviceRef = useRef(interpret(createResolverMachine(identifier), () => forceUpdate({})));
+  const [, forceUpdate] = useState({});
   const { exit } = useApp();
 
-  const getConnectionError = useCallback(() => {
-    if (isApiLocalDevMode()) {
-      return {
-        title: 'Connection Error',
-        message: 'Error connecting to the local development server.',
-        details: "Please ensure the server is running ('positronic server' or 'px s').",
-      };
-    } else {
-      return {
-        title: 'Connection Error',
-        message: 'Error connecting to the remote project server.',
-        details: 'Please check your network connection and verify the project URL is correct.',
-      };
-    }
-  }, []);
+  const { machine, context, send } = serviceRef.current;
+  const currentState = machine.current as string;
+  const {
+    brains,
+    selectedIndex,
+    resolvedBrainTitle,
+    resolvedRunId,
+    activeRuns,
+    error,
+  } = context as ResolverContext;
 
-  // Phase 1: Search for brain by name
+  // Single effect that runs async operations based on current state
   useEffect(() => {
-    if (phase !== 'searching-brain') return;
+    let cancelled = false;
 
-    const searchBrains = async () => {
-      try {
-        const url = `/brains?q=${encodeURIComponent(identifier)}`;
-        const response = await apiClient.fetch(url, { method: 'GET' });
+    const runStateAction = async () => {
+      switch (currentState) {
+        case 'searchingBrain': {
+          try {
+            const url = `/brains?q=${encodeURIComponent(identifier)}`;
+            const response = await apiClient.fetch(url, { method: 'GET' });
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          setError({
-            title: 'Server Error',
-            message: `Error searching for brains: ${response.status} ${response.statusText}`,
-            details: errorText,
-          });
-          setPhase('error');
-          return;
-        }
+            if (cancelled) return;
 
-        const data = (await response.json()) as BrainsResponse;
+            if (!response.ok) {
+              const errorText = await response.text();
+              send({
+                type: EVENTS.ERROR,
+                error: {
+                  title: 'Server Error',
+                  message: `Error searching for brains: ${response.status} ${response.statusText}`,
+                  details: errorText,
+                },
+              } as any);
+              return;
+            }
 
-        if (data.count === 0) {
-          // No brain found, try as run ID
-          setPhase('searching-run');
-        } else if (data.count === 1) {
-          // Exactly one brain match - look up active runs
-          setResolvedBrainTitle(data.brains[0].title);
-          setPhase('fetching-active-runs');
-        } else {
-          // Multiple brain matches - show disambiguation UI
-          setBrains(data.brains);
-          setPhase('disambiguating');
-        }
-      } catch (err: any) {
-        const baseError = getConnectionError();
-        setError({
-          ...baseError,
-          details: `${baseError.details} ${err.message}`,
-        });
-        setPhase('error');
-      }
-    };
+            const { brains: foundBrains, count } = (await response.json()) as BrainsResponse;
 
-    searchBrains();
-  }, [phase, identifier, getConnectionError]);
+            if (cancelled) return;
 
-  // Phase 2: If no brain found, try as run ID
-  useEffect(() => {
-    if (phase !== 'searching-run') return;
-
-    const searchRun = async () => {
-      try {
-        const url = `/brains/runs/${encodeURIComponent(identifier)}`;
-        const response = await apiClient.fetch(url, { method: 'GET' });
-
-        if (response.ok) {
-          // Found as run ID - watch it directly
-          const data = (await response.json()) as BrainRun;
-          setResolvedRunId(data.brainRunId);
-          setPhase('resolved-run');
-        } else if (response.status === 404) {
-          // Neither brain nor run found
-          setError({
-            title: 'Not Found',
-            message: `No brain or run found matching '${identifier}'.`,
-            details:
-              'Please check that:\n' +
-              '  1. The brain name or run ID is correct\n' +
-              '  2. The brain exists in your project\n' +
-              '\nYou can list available brains with: positronic list',
-          });
-          setPhase('error');
-        } else {
-          const errorText = await response.text();
-          setError({
-            title: 'Server Error',
-            message: `Error looking up run: ${response.status} ${response.statusText}`,
-            details: errorText,
-          });
-          setPhase('error');
-        }
-      } catch (err: any) {
-        const baseError = getConnectionError();
-        setError({
-          ...baseError,
-          details: `${baseError.details} ${err.message}`,
-        });
-        setPhase('error');
-      }
-    };
-
-    searchRun();
-  }, [phase, identifier, getConnectionError]);
-
-  // Phase 3: Fetch active runs for resolved brain
-  useEffect(() => {
-    if (phase !== 'fetching-active-runs' || !resolvedBrainTitle) return;
-
-    const fetchActiveRuns = async () => {
-      try {
-        const apiPath = `/brains/${encodeURIComponent(resolvedBrainTitle)}/active-runs`;
-        const response = await apiClient.fetch(apiPath, { method: 'GET' });
-
-        if (response.status === 200) {
-          const result = (await response.json()) as ActiveRunsResponse;
-
-          if (result.runs.length === 0) {
-            setPhase('no-active-runs');
-          } else if (result.runs.length === 1) {
-            setResolvedRunId(result.runs[0].brainRunId);
-            setPhase('resolved-run');
-          } else {
-            setActiveRuns(result.runs);
-            setPhase('multiple-active-runs');
+            if (count === 0) {
+              send({ type: EVENTS.BRAIN_NOT_FOUND } as any);
+            } else if (count === 1) {
+              send({ type: EVENTS.BRAIN_FOUND, brainTitle: foundBrains[0].title } as any);
+            } else {
+              send({ type: EVENTS.BRAINS_MULTIPLE, brains: foundBrains } as any);
+            }
+          } catch (err: any) {
+            if (cancelled) return;
+            const baseError = getConnectionError();
+            send({
+              type: EVENTS.ERROR,
+              error: { ...baseError, details: `${baseError.details} ${err.message}` },
+            } as any);
           }
-        } else {
-          const errorText = await response.text();
-          setError({
-            title: 'API Error',
-            message: `Failed to get active runs for brain "${resolvedBrainTitle}".`,
-            details: `Server returned ${response.status}: ${errorText}`,
-          });
-          setPhase('error');
+          break;
         }
-      } catch (err: any) {
-        const baseError = getConnectionError();
-        setError({
-          ...baseError,
-          details: `${baseError.details} ${err.message}`,
-        });
-        setPhase('error');
+
+        case 'searchingRun': {
+          try {
+            const url = `/brains/runs/${encodeURIComponent(identifier)}`;
+            const response = await apiClient.fetch(url, { method: 'GET' });
+
+            if (cancelled) return;
+
+            if (response.ok) {
+              const { brainRunId } = (await response.json()) as BrainRun;
+              send({ type: EVENTS.RUN_FOUND, runId: brainRunId } as any);
+            } else if (response.status === 404) {
+              send({
+                type: EVENTS.NOT_FOUND,
+                error: {
+                  title: 'Not Found',
+                  message: `No brain or run found matching '${identifier}'.`,
+                  details:
+                    'Please check that:\n' +
+                    '  1. The brain name or run ID is correct\n' +
+                    '  2. The brain exists in your project\n' +
+                    '\nYou can list available brains with: positronic list',
+                },
+              } as any);
+            } else {
+              const errorText = await response.text();
+              send({
+                type: EVENTS.ERROR,
+                error: {
+                  title: 'Server Error',
+                  message: `Error looking up run: ${response.status} ${response.statusText}`,
+                  details: errorText,
+                },
+              } as any);
+            }
+          } catch (err: any) {
+            if (cancelled) return;
+            const baseError = getConnectionError();
+            send({
+              type: EVENTS.ERROR,
+              error: { ...baseError, details: `${baseError.details} ${err.message}` },
+            } as any);
+          }
+          break;
+        }
+
+        case 'fetchingActiveRuns': {
+          if (!resolvedBrainTitle) return;
+
+          try {
+            const apiPath = `/brains/${encodeURIComponent(resolvedBrainTitle)}/active-runs`;
+            const response = await apiClient.fetch(apiPath, { method: 'GET' });
+
+            if (cancelled) return;
+
+            if (response.status === 200) {
+              const { runs } = (await response.json()) as ActiveRunsResponse;
+
+              if (runs.length === 0) {
+                send({ type: EVENTS.NO_ACTIVE_RUNS } as any);
+              } else if (runs.length === 1) {
+                send({ type: EVENTS.ACTIVE_RUN_FOUND, runId: runs[0].brainRunId } as any);
+              } else {
+                send({ type: EVENTS.MULTIPLE_ACTIVE_RUNS, runs } as any);
+              }
+            } else {
+              const errorText = await response.text();
+              send({
+                type: EVENTS.ERROR,
+                error: {
+                  title: 'API Error',
+                  message: `Failed to get active runs for brain "${resolvedBrainTitle}".`,
+                  details: `Server returned ${response.status}: ${errorText}`,
+                },
+              } as any);
+            }
+          } catch (err: any) {
+            if (cancelled) return;
+            const baseError = getConnectionError();
+            send({
+              type: EVENTS.ERROR,
+              error: { ...baseError, details: `${baseError.details} ${err.message}` },
+            } as any);
+          }
+          break;
+        }
       }
     };
 
-    fetchActiveRuns();
-  }, [phase, resolvedBrainTitle, getConnectionError]);
+    runStateAction();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentState, identifier, resolvedBrainTitle, send]);
 
   // Handle keyboard input for brain disambiguation
   useInput((input, key) => {
-    if (phase !== 'disambiguating') return;
+    if (currentState !== 'disambiguating') return;
 
     if (key.upArrow) {
-      setSelectedIndex((prev) => (prev - 1 + brains.length) % brains.length);
+      (context as ResolverContext).selectedIndex =
+        (selectedIndex - 1 + brains.length) % brains.length;
+      forceUpdate({});
     } else if (key.downArrow) {
-      setSelectedIndex((prev) => (prev + 1) % brains.length);
+      (context as ResolverContext).selectedIndex =
+        (selectedIndex + 1) % brains.length;
+      forceUpdate({});
     } else if (key.return) {
-      const selectedBrain = brains[selectedIndex];
-      setResolvedBrainTitle(selectedBrain.title);
-      setPhase('fetching-active-runs');
+      const { title } = brains[selectedIndex];
+      send({ type: EVENTS.BRAIN_SELECTED, brainTitle: title } as any);
     } else if (input === 'q' || key.escape) {
       exit();
     }
   });
 
-  // Render based on phase
-  if (phase === 'searching-brain') {
-    return (
-      <Box>
-        <Text>Searching for '{identifier}'...</Text>
-      </Box>
-    );
-  }
-
-  if (phase === 'searching-run') {
-    return (
-      <Box>
-        <Text>Checking if '{identifier}' is a run ID...</Text>
-      </Box>
-    );
-  }
-
-  if (phase === 'fetching-active-runs') {
-    return (
-      <Box>
-        <Text>Looking for active runs for "{resolvedBrainTitle}"...</Text>
-      </Box>
-    );
-  }
-
-  if (phase === 'error' && error) {
-    return <ErrorComponent error={error} />;
-  }
-
-  if (phase === 'disambiguating') {
-    return (
-      <Box flexDirection="column">
-        <Text bold>Multiple brains match '{identifier}':</Text>
-        <Box marginTop={1} flexDirection="column">
-          {brains.map((brain, index) => {
-            const isSelected = index === selectedIndex;
-            return (
-              <Box key={brain.title} flexDirection="column" marginBottom={1}>
-                <Text color={isSelected ? 'cyan' : undefined}>
-                  {isSelected ? '> ' : '  '}
-                  <Text bold>{brain.title}</Text>
-                </Text>
-                <Text dimColor>
-                  {'    '}
-                  {brain.description}
-                </Text>
-              </Box>
-            );
-          })}
+  // Render based on state
+  switch (currentState) {
+    case 'searchingBrain':
+      return (
+        <Box>
+          <Text>Searching for '{identifier}'...</Text>
         </Box>
-        <Box marginTop={1}>
-          <Text dimColor>Use arrow keys to navigate, Enter to select, q to quit</Text>
+      );
+
+    case 'searchingRun':
+      return (
+        <Box>
+          <Text>Checking if '{identifier}' is a run ID...</Text>
         </Box>
-      </Box>
-    );
-  }
+      );
 
-  if (phase === 'no-active-runs') {
-    return (
-      <ErrorComponent
-        error={{
-          title: 'No Active Runs',
-          message: `No currently running brain runs found for brain "${resolvedBrainTitle}".`,
-          details: `To start a new run, use: positronic run ${resolvedBrainTitle}`,
-        }}
-      />
-    );
-  }
+    case 'fetchingActiveRuns':
+      return (
+        <Box>
+          <Text>Looking for active runs for "{resolvedBrainTitle}"...</Text>
+        </Box>
+      );
 
-  if (phase === 'multiple-active-runs') {
-    return (
-      <ErrorComponent
-        error={{
-          title: 'Multiple Active Runs',
-          message: `Found ${activeRuns.length} active runs for brain "${resolvedBrainTitle}".`,
-          details: `Please specify a specific run ID:\n${activeRuns.map((run) => `  positronic watch ${run.brainRunId}`).join('\n')}`,
-        }}
-      />
-    );
-  }
+    case 'disambiguating':
+      return (
+        <Box flexDirection="column">
+          <Text bold>Multiple brains match '{identifier}':</Text>
+          <Box marginTop={1} flexDirection="column">
+            {brains.map((brain, index) => {
+              const isSelected = index === selectedIndex;
+              const { title, description } = brain;
+              return (
+                <Box key={title} flexDirection="column" marginBottom={1}>
+                  <Text color={isSelected ? 'cyan' : undefined}>
+                    {isSelected ? '> ' : '  '}
+                    <Text bold>{title}</Text>
+                  </Text>
+                  <Text dimColor>
+                    {'    '}
+                    {description}
+                  </Text>
+                </Box>
+              );
+            })}
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>Use arrow keys to navigate, Enter to select, q to quit</Text>
+          </Box>
+        </Box>
+      );
 
-  if (phase === 'resolved-run' && resolvedRunId) {
-    return <Watch runId={resolvedRunId} />;
-  }
+    case 'noActiveRuns':
+      return (
+        <ErrorComponent
+          error={{
+            title: 'No Active Runs',
+            message: `No currently running brain runs found for brain "${resolvedBrainTitle}".`,
+            details: `To start a new run, use: positronic run ${resolvedBrainTitle}`,
+          }}
+        />
+      );
 
-  return null;
+    case 'multipleActiveRuns':
+      return (
+        <ErrorComponent
+          error={{
+            title: 'Multiple Active Runs',
+            message: `Found ${activeRuns.length} active runs for brain "${resolvedBrainTitle}".`,
+            details: `Please specify a specific run ID:\n${activeRuns.map(({ brainRunId }) => `  positronic watch ${brainRunId}`).join('\n')}`,
+          }}
+        />
+      );
+
+    case 'error':
+      return error ? <ErrorComponent error={error} /> : null;
+
+    case 'resolved':
+      return resolvedRunId ? <Watch runId={resolvedRunId} /> : null;
+
+    default:
+      return null;
+  }
 };

--- a/packages/cli/src/components/watch-resolver.tsx
+++ b/packages/cli/src/components/watch-resolver.tsx
@@ -1,0 +1,328 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useInput, useApp } from 'ink';
+import { Watch } from './watch.js';
+import { ErrorComponent } from './error.js';
+import { apiClient, isApiLocalDevMode } from '../commands/helpers.js';
+import { STATUS } from '@positronic/core';
+
+interface Brain {
+  title: string;
+  description: string;
+}
+
+interface BrainsResponse {
+  brains: Brain[];
+  count: number;
+}
+
+interface ActiveRunsResponse {
+  runs: Array<{
+    brainRunId: string;
+    brainTitle: string;
+    status: string;
+    createdAt: number;
+  }>;
+}
+
+interface BrainRun {
+  brainRunId: string;
+  brainTitle: string;
+  status: string;
+}
+
+interface WatchResolverProps {
+  identifier: string;
+}
+
+type Phase =
+  | 'searching-brain'
+  | 'searching-run'
+  | 'disambiguating'
+  | 'fetching-active-runs'
+  | 'resolved-run'
+  | 'no-active-runs'
+  | 'multiple-active-runs'
+  | 'error';
+
+/**
+ * WatchResolver - Resolves an identifier to either a brain name or run ID and starts watching.
+ *
+ * Resolution order:
+ * 1. Try to resolve as a brain name (fuzzy search)
+ * 2. If no brain matches, try as a run ID
+ * 3. If neither works, show an error
+ *
+ * If resolved as a brain, looks up active runs and watches the appropriate one.
+ */
+export const WatchResolver = ({ identifier }: WatchResolverProps) => {
+  const [phase, setPhase] = useState<Phase>('searching-brain');
+  const [brains, setBrains] = useState<Brain[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [resolvedRunId, setResolvedRunId] = useState<string | null>(null);
+  const [resolvedBrainTitle, setResolvedBrainTitle] = useState<string | null>(null);
+  const [activeRuns, setActiveRuns] = useState<ActiveRunsResponse['runs']>([]);
+  const [error, setError] = useState<{
+    title: string;
+    message: string;
+    details?: string;
+  } | null>(null);
+  const { exit } = useApp();
+
+  const getConnectionError = useCallback(() => {
+    if (isApiLocalDevMode()) {
+      return {
+        title: 'Connection Error',
+        message: 'Error connecting to the local development server.',
+        details: "Please ensure the server is running ('positronic server' or 'px s').",
+      };
+    } else {
+      return {
+        title: 'Connection Error',
+        message: 'Error connecting to the remote project server.',
+        details: 'Please check your network connection and verify the project URL is correct.',
+      };
+    }
+  }, []);
+
+  // Phase 1: Search for brain by name
+  useEffect(() => {
+    if (phase !== 'searching-brain') return;
+
+    const searchBrains = async () => {
+      try {
+        const url = `/brains?q=${encodeURIComponent(identifier)}`;
+        const response = await apiClient.fetch(url, { method: 'GET' });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          setError({
+            title: 'Server Error',
+            message: `Error searching for brains: ${response.status} ${response.statusText}`,
+            details: errorText,
+          });
+          setPhase('error');
+          return;
+        }
+
+        const data = (await response.json()) as BrainsResponse;
+
+        if (data.count === 0) {
+          // No brain found, try as run ID
+          setPhase('searching-run');
+        } else if (data.count === 1) {
+          // Exactly one brain match - look up active runs
+          setResolvedBrainTitle(data.brains[0].title);
+          setPhase('fetching-active-runs');
+        } else {
+          // Multiple brain matches - show disambiguation UI
+          setBrains(data.brains);
+          setPhase('disambiguating');
+        }
+      } catch (err: any) {
+        const baseError = getConnectionError();
+        setError({
+          ...baseError,
+          details: `${baseError.details} ${err.message}`,
+        });
+        setPhase('error');
+      }
+    };
+
+    searchBrains();
+  }, [phase, identifier, getConnectionError]);
+
+  // Phase 2: If no brain found, try as run ID
+  useEffect(() => {
+    if (phase !== 'searching-run') return;
+
+    const searchRun = async () => {
+      try {
+        const url = `/brains/runs/${encodeURIComponent(identifier)}`;
+        const response = await apiClient.fetch(url, { method: 'GET' });
+
+        if (response.ok) {
+          // Found as run ID - watch it directly
+          const data = (await response.json()) as BrainRun;
+          setResolvedRunId(data.brainRunId);
+          setPhase('resolved-run');
+        } else if (response.status === 404) {
+          // Neither brain nor run found
+          setError({
+            title: 'Not Found',
+            message: `No brain or run found matching '${identifier}'.`,
+            details:
+              'Please check that:\n' +
+              '  1. The brain name or run ID is correct\n' +
+              '  2. The brain exists in your project\n' +
+              '\nYou can list available brains with: positronic list',
+          });
+          setPhase('error');
+        } else {
+          const errorText = await response.text();
+          setError({
+            title: 'Server Error',
+            message: `Error looking up run: ${response.status} ${response.statusText}`,
+            details: errorText,
+          });
+          setPhase('error');
+        }
+      } catch (err: any) {
+        const baseError = getConnectionError();
+        setError({
+          ...baseError,
+          details: `${baseError.details} ${err.message}`,
+        });
+        setPhase('error');
+      }
+    };
+
+    searchRun();
+  }, [phase, identifier, getConnectionError]);
+
+  // Phase 3: Fetch active runs for resolved brain
+  useEffect(() => {
+    if (phase !== 'fetching-active-runs' || !resolvedBrainTitle) return;
+
+    const fetchActiveRuns = async () => {
+      try {
+        const apiPath = `/brains/${encodeURIComponent(resolvedBrainTitle)}/active-runs`;
+        const response = await apiClient.fetch(apiPath, { method: 'GET' });
+
+        if (response.status === 200) {
+          const result = (await response.json()) as ActiveRunsResponse;
+
+          if (result.runs.length === 0) {
+            setPhase('no-active-runs');
+          } else if (result.runs.length === 1) {
+            setResolvedRunId(result.runs[0].brainRunId);
+            setPhase('resolved-run');
+          } else {
+            setActiveRuns(result.runs);
+            setPhase('multiple-active-runs');
+          }
+        } else {
+          const errorText = await response.text();
+          setError({
+            title: 'API Error',
+            message: `Failed to get active runs for brain "${resolvedBrainTitle}".`,
+            details: `Server returned ${response.status}: ${errorText}`,
+          });
+          setPhase('error');
+        }
+      } catch (err: any) {
+        const baseError = getConnectionError();
+        setError({
+          ...baseError,
+          details: `${baseError.details} ${err.message}`,
+        });
+        setPhase('error');
+      }
+    };
+
+    fetchActiveRuns();
+  }, [phase, resolvedBrainTitle, getConnectionError]);
+
+  // Handle keyboard input for brain disambiguation
+  useInput((input, key) => {
+    if (phase !== 'disambiguating') return;
+
+    if (key.upArrow) {
+      setSelectedIndex((prev) => (prev - 1 + brains.length) % brains.length);
+    } else if (key.downArrow) {
+      setSelectedIndex((prev) => (prev + 1) % brains.length);
+    } else if (key.return) {
+      const selectedBrain = brains[selectedIndex];
+      setResolvedBrainTitle(selectedBrain.title);
+      setPhase('fetching-active-runs');
+    } else if (input === 'q' || key.escape) {
+      exit();
+    }
+  });
+
+  // Render based on phase
+  if (phase === 'searching-brain') {
+    return (
+      <Box>
+        <Text>Searching for '{identifier}'...</Text>
+      </Box>
+    );
+  }
+
+  if (phase === 'searching-run') {
+    return (
+      <Box>
+        <Text>Checking if '{identifier}' is a run ID...</Text>
+      </Box>
+    );
+  }
+
+  if (phase === 'fetching-active-runs') {
+    return (
+      <Box>
+        <Text>Looking for active runs for "{resolvedBrainTitle}"...</Text>
+      </Box>
+    );
+  }
+
+  if (phase === 'error' && error) {
+    return <ErrorComponent error={error} />;
+  }
+
+  if (phase === 'disambiguating') {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Multiple brains match '{identifier}':</Text>
+        <Box marginTop={1} flexDirection="column">
+          {brains.map((brain, index) => {
+            const isSelected = index === selectedIndex;
+            return (
+              <Box key={brain.title} flexDirection="column" marginBottom={1}>
+                <Text color={isSelected ? 'cyan' : undefined}>
+                  {isSelected ? '> ' : '  '}
+                  <Text bold>{brain.title}</Text>
+                </Text>
+                <Text dimColor>
+                  {'    '}
+                  {brain.description}
+                </Text>
+              </Box>
+            );
+          })}
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Use arrow keys to navigate, Enter to select, q to quit</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (phase === 'no-active-runs') {
+    return (
+      <ErrorComponent
+        error={{
+          title: 'No Active Runs',
+          message: `No currently running brain runs found for brain "${resolvedBrainTitle}".`,
+          details: `To start a new run, use: positronic run ${resolvedBrainTitle}`,
+        }}
+      />
+    );
+  }
+
+  if (phase === 'multiple-active-runs') {
+    return (
+      <ErrorComponent
+        error={{
+          title: 'Multiple Active Runs',
+          message: `Found ${activeRuns.length} active runs for brain "${resolvedBrainTitle}".`,
+          details: `Please specify a specific run ID:\n${activeRuns.map((run) => `  positronic watch ${run.brainRunId}`).join('\n')}`,
+        }}
+      />
+    );
+  }
+
+  if (phase === 'resolved-run' && resolvedRunId) {
+    return <Watch runId={resolvedRunId} />;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary

The watch command now accepts a single positional argument that can be either a brain name or a run ID:

```bash
px watch my-brain              # Tries as brain name first
px watch 6ed97694-b185-...     # Falls back to run ID if brain not found
```

Previously, users had to know which type of identifier they had and use different syntax:
- `px watch my-brain` for brain names
- `px watch --run-id abc123` for run IDs

This was cumbersome especially when copying run IDs from logs or notifications.

## Changes

- **Add WatchResolver component** - New resolver that tries brain name first, then falls back to run ID lookup
- **Unify CLI interface** - Single `<identifier>` positional instead of optional brain + `--run-id` flag  
- **Update suggestions** - Rerun command now shows `positronic watch <id>` instead of `positronic watch --run-id <id>`
- **Update tests** - Add tests for fallback behavior and update existing tests for new syntax

## Test plan

- [x] All existing tests pass
- [x] New tests verify brain name → run ID fallback
- [x] New tests verify proper error when neither found
- [x] Manual testing: `px watch brain-name`, `px watch run-id`, `px watch nonexistent`