### PR TITLE
Add root public key setup flow for authentication

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1429,6 +1429,30 @@ export function buildCli(options: CliOptions) {
             }
           )
           .command(
+            'format-jwk-key',
+            'Convert an SSH public key to JWK format for ROOT_PUBLIC_KEY\n',
+            (yargsFormatJwkKey) => {
+              return yargsFormatJwkKey
+                .option('pubkey', {
+                  describe: 'Path to SSH public key file',
+                  type: 'string',
+                  alias: 'p',
+                })
+                .example(
+                  '$0 auth format-jwk-key',
+                  'Interactive public key selection'
+                )
+                .example(
+                  '$0 auth format-jwk-key --pubkey ~/.ssh/id_ed25519.pub',
+                  'Convert specific key'
+                );
+            },
+            (argv) => {
+              const element = authCommand.formatJwkKey(argv as any);
+              render(element);
+            }
+          )
+          .command(
             '$0',
             false, // Hidden command - default action
             () => {},

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,6 +4,7 @@ import { AuthStatus } from '../components/auth-status.js';
 import { AuthLogin } from '../components/auth-login.js';
 import { AuthLogout } from '../components/auth-logout.js';
 import { AuthList } from '../components/auth-list.js';
+import { AuthFormatJwkKey } from '../components/auth-format-jwk-key.js';
 import { ProjectConfigManager } from './project-config-manager.js';
 
 interface LoginArgs {
@@ -13,6 +14,10 @@ interface LoginArgs {
 
 interface LogoutArgs {
   project?: boolean;
+}
+
+interface FormatJwkKeyArgs {
+  pubkey?: string;
 }
 
 export class AuthCommand {
@@ -62,6 +67,16 @@ export class AuthCommand {
   list(): React.ReactElement {
     return React.createElement(AuthList, {
       configManager: this.configManager,
+    });
+  }
+
+  /**
+   * Handles the 'px auth format-jwk-key' command.
+   * Convert an SSH public key to JWK format for ROOT_PUBLIC_KEY configuration.
+   */
+  formatJwkKey({ pubkey }: ArgumentsCamelCase<FormatJwkKeyArgs>): React.ReactElement {
+    return React.createElement(AuthFormatJwkKey, {
+      pubkeyPath: pubkey,
     });
   }
 }

--- a/packages/cli/src/commands/helpers.ts
+++ b/packages/cli/src/commands/helpers.ts
@@ -108,6 +108,28 @@ export const apiClient = {
 
     return fetch(fullUrl, requestOptions);
   },
+
+  /**
+   * Fetch without authentication - used for unauthenticated endpoints like /auth/setup
+   */
+  fetchUnauthenticated: async (apiPath: string, options?: RequestInit): Promise<Response> => {
+    let baseUrl: string;
+
+    if (apiBaseUrl) {
+      baseUrl = apiBaseUrl;
+    } else {
+      // Fallback to localhost (for backwards compatibility and testing)
+      const port = process.env.POSITRONIC_PORT || '8787';
+      baseUrl = `http://localhost:${port}`;
+    }
+
+    const fullUrl = `${baseUrl}${
+      apiPath.startsWith('/') ? apiPath : '/' + apiPath
+    }`;
+
+    // Don't sign the request - this is for unauthenticated endpoints
+    return fetch(fullUrl, options);
+  },
 };
 
 export async function generateProject(projectName: string, projectDir: string) {

--- a/packages/cli/src/components/auth-format-jwk-key.tsx
+++ b/packages/cli/src/components/auth-format-jwk-key.tsx
@@ -1,0 +1,223 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useApp } from 'ink';
+import { existsSync, readdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { convertSSHPubKeyToJWK, expandPath } from '../lib/ssh-key-utils.js';
+import { SelectList, type SelectListItem } from './select-list.js';
+
+interface AuthFormatJwkKeyProps {
+  pubkeyPath?: string;
+}
+
+interface DiscoveredPubKey {
+  path: string;
+  displayPath: string;
+}
+
+type ComponentState = 'selecting' | 'success' | 'error' | 'no-keys';
+
+/**
+ * Discover available SSH public keys in ~/.ssh
+ */
+function discoverSSHPubKeys(): DiscoveredPubKey[] {
+  const sshDir = join(homedir(), '.ssh');
+
+  if (!existsSync(sshDir)) {
+    return [];
+  }
+
+  const pubKeys: DiscoveredPubKey[] = [];
+
+  try {
+    const files = readdirSync(sshDir);
+    for (const file of files) {
+      if (file.endsWith('.pub')) {
+        const fullPath = join(sshDir, file);
+        pubKeys.push({
+          path: fullPath,
+          displayPath: `~/.ssh/${file}`,
+        });
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return pubKeys;
+}
+
+/**
+ * Copy text to clipboard using pbcopy (macOS) or xclip (Linux)
+ */
+async function copyToClipboard(text: string): Promise<boolean> {
+  const { spawn } = await import('child_process');
+
+  return new Promise((resolve) => {
+    // Try pbcopy first (macOS)
+    let proc = spawn('pbcopy', [], { stdio: ['pipe', 'ignore', 'ignore'] });
+    proc.on('error', () => {
+      // Try xclip (Linux)
+      proc = spawn('xclip', ['-selection', 'clipboard'], { stdio: ['pipe', 'ignore', 'ignore'] });
+      proc.on('error', () => {
+        resolve(false);
+      });
+      proc.on('close', (code) => {
+        resolve(code === 0);
+      });
+      proc.stdin?.write(text);
+      proc.stdin?.end();
+    });
+    proc.on('close', (code) => {
+      resolve(code === 0);
+    });
+    proc.stdin?.write(text);
+    proc.stdin?.end();
+  });
+}
+
+export const AuthFormatJwkKey = ({ pubkeyPath }: AuthFormatJwkKeyProps) => {
+  const { exit } = useApp();
+  const [state, setState] = useState<ComponentState>(pubkeyPath ? 'success' : 'selecting');
+  const [error, setError] = useState<string | null>(null);
+  const [jwkOutput, setJwkOutput] = useState<string | null>(null);
+  const [fingerprint, setFingerprint] = useState<string | null>(null);
+  const [copiedToClipboard, setCopiedToClipboard] = useState<boolean>(false);
+  const [selectedPath, setSelectedPath] = useState<string | null>(pubkeyPath || null);
+
+  // Handle direct path provided via --pubkey
+  useEffect(() => {
+    if (pubkeyPath && state === 'success' && !jwkOutput) {
+      processKey(pubkeyPath);
+    }
+  }, [pubkeyPath, state, jwkOutput]);
+
+  const processKey = async (keyPath: string) => {
+    try {
+      const expandedPath = expandPath(keyPath);
+
+      if (!existsSync(expandedPath)) {
+        setError(`Public key file not found: ${keyPath}`);
+        setState('error');
+        return;
+      }
+
+      const keyInfo = convertSSHPubKeyToJWK(expandedPath);
+      const jwkString = JSON.stringify(keyInfo.jwk, null, 2);
+
+      setJwkOutput(jwkString);
+      setFingerprint(keyInfo.fingerprint);
+      setSelectedPath(keyPath);
+
+      // Try to copy to clipboard
+      const copied = await copyToClipboard(jwkString);
+      setCopiedToClipboard(copied);
+
+      setState('success');
+    } catch (err: any) {
+      setError(err.message || 'Failed to convert key');
+      setState('error');
+    }
+  };
+
+  // Check for available keys when in selecting state
+  const pubKeys = discoverSSHPubKeys();
+
+  if (state === 'selecting' && pubKeys.length === 0) {
+    return (
+      <Box flexDirection="column" paddingTop={1} paddingBottom={1}>
+        <Text color="yellow">No SSH public keys found in ~/.ssh/</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>Generate a new SSH key with:</Text>
+          <Box marginLeft={2} marginTop={1}>
+            <Text color="cyan">ssh-keygen -t ed25519 -C "your-email@example.com"</Text>
+          </Box>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>
+            Or specify a public key path with: px auth format-jwk-key --pubkey /path/to/key.pub
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (state === 'selecting') {
+    const items: SelectListItem[] = pubKeys.map((key) => ({
+      id: key.path,
+      label: key.displayPath,
+      description: '',
+    }));
+
+    const handleSelect = async (item: SelectListItem) => {
+      await processKey(item.id);
+    };
+
+    const handleCancel = () => {
+      exit();
+    };
+
+    return (
+      <SelectList
+        items={items}
+        header="Select an SSH public key to convert to JWK format"
+        onSelect={handleSelect}
+        onCancel={handleCancel}
+        footer="Use arrow keys to navigate, Enter to select, q to cancel"
+      />
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <Box flexDirection="column" paddingTop={1} paddingBottom={1}>
+        <Text color="red">Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  if (state === 'success' && jwkOutput) {
+    const displayPath = selectedPath?.startsWith(homedir())
+      ? selectedPath.replace(homedir(), '~')
+      : selectedPath;
+
+    return (
+      <Box flexDirection="column" paddingTop={1} paddingBottom={1}>
+        <Text bold color="green">JWK Public Key</Text>
+
+        <Box marginTop={1}>
+          <Text dimColor>Source: {displayPath}</Text>
+        </Box>
+        {fingerprint && (
+          <Box>
+            <Text dimColor>Fingerprint: {fingerprint}</Text>
+          </Box>
+        )}
+
+        <Box marginTop={1} flexDirection="column">
+          <Text color="cyan">{jwkOutput}</Text>
+        </Box>
+
+        <Box marginTop={1}>
+          {copiedToClipboard ? (
+            <Text color="green">Copied to clipboard.</Text>
+          ) : (
+            <Text color="yellow">Could not copy to clipboard - copy the value above manually.</Text>
+          )}
+        </Box>
+
+        <Box marginTop={1} flexDirection="column">
+          <Text bold>Next steps:</Text>
+          <Box marginLeft={2} marginTop={1} flexDirection="column">
+            <Text>1. Go to Cloudflare dashboard</Text>
+            <Text>2. Navigate to Workers & Pages {'>'} Your project {'>'} Settings {'>'} Variables and Secrets</Text>
+            <Text>3. Add a new secret named <Text color="cyan">ROOT_PUBLIC_KEY</Text></Text>
+            <Text>4. Paste the JWK value above</Text>
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/packages/cli/src/hooks/useApi.ts
+++ b/packages/cli/src/hooks/useApi.ts
@@ -22,13 +22,9 @@ function getConnectionErrorMessage(): { title: string; message: string; details:
  * Fetch auth setup instructions from the server
  */
 async function fetchAuthSetupInstructions(): Promise<AuthSetupResponse | null> {
-  try {
-    const response = await apiClient.fetchUnauthenticated('/auth/setup');
-    if (response.ok) {
-      return (await response.json()) as AuthSetupResponse;
-    }
-  } catch {
-    // If we can't fetch setup instructions, fall back to generic message
+  const response = await apiClient.fetchUnauthenticated('/auth/setup');
+  if (response.ok) {
+    return (await response.json()) as AuthSetupResponse;
   }
   return null;
 }

--- a/packages/cloudflare/src/api/auth-middleware.ts
+++ b/packages/cloudflare/src/api/auth-middleware.ts
@@ -216,6 +216,10 @@ export function authMiddleware(): MiddlewareHandler<{ Bindings: Bindings }> {
     }
 
     // No matching key found
+    // Check if ROOT_PUBLIC_KEY is configured - if not, return specific error
+    if (!c.env.ROOT_PUBLIC_KEY) {
+      return c.json({ error: 'ROOT_KEY_NOT_CONFIGURED' }, 401);
+    }
     return c.json({ error: 'Unknown key' }, 401);
   };
 }

--- a/packages/spec/src/api/auth.ts
+++ b/packages/spec/src/api/auth.ts
@@ -1,0 +1,51 @@
+import type { Fetch } from './types.js';
+
+export interface AuthSetupResponse {
+  backend: string;
+  rootKeyConfigured: boolean;
+  instructions: string;
+}
+
+export const auth = {
+  /**
+   * Test GET /auth/setup - Unauthenticated endpoint returning setup instructions
+   * This endpoint should be accessible without authentication
+   */
+  async setup(fetch: Fetch): Promise<boolean> {
+    try {
+      const request = new Request('http://example.com/auth/setup', {
+        method: 'GET',
+      });
+
+      const response = await fetch(request);
+
+      if (!response.ok) {
+        console.error(`GET /auth/setup returned ${response.status}`);
+        return false;
+      }
+
+      const data = (await response.json()) as AuthSetupResponse;
+
+      // Validate response structure
+      if (typeof data.backend !== 'string') {
+        console.error(`Expected backend to be string, got ${typeof data.backend}`);
+        return false;
+      }
+
+      if (typeof data.rootKeyConfigured !== 'boolean') {
+        console.error(`Expected rootKeyConfigured to be boolean, got ${typeof data.rootKeyConfigured}`);
+        return false;
+      }
+
+      if (typeof data.instructions !== 'string') {
+        console.error(`Expected instructions to be string, got ${typeof data.instructions}`);
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      console.error(`Failed to test GET /auth/setup:`, error);
+      return false;
+    }
+  },
+};

--- a/packages/spec/src/api/index.ts
+++ b/packages/spec/src/api/index.ts
@@ -8,4 +8,6 @@ export { signals } from './signals.js';
 export { pages } from './pages.js';
 export { bundle } from './bundle.js';
 export { users } from './users.js';
+export { auth } from './auth.js';
 export type { User, UserKey } from './users.js';
+export type { AuthSetupResponse } from './auth.js';

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -133,4 +133,5 @@ export interface PositronicDevServer {
   bulkSecrets(filePath: string): Promise<void>;
 }
 
-export { testStatus, resources, brains, schedules, secrets, webhooks, signals, pages, bundle } from './api/index.js';
+export { testStatus, resources, brains, schedules, secrets, webhooks, signals, pages, bundle, auth } from './api/index.js';
+export type { AuthSetupResponse } from './api/index.js';


### PR DESCRIPTION
- Add new auth spec module with /auth/setup endpoint test
- Add specs for ROOT_PUBLIC_KEY protection (create/delete rejection, list exclusion)
- Protect ROOT_PUBLIC_KEY in cloudflare secrets API (cannot be set/deleted via API)
- Add ROOT_KEY_NOT_CONFIGURED error in auth middleware when root key missing
- Add unauthenticated /auth/setup endpoint returning backend-specific instructions
- Update CLI useApi hooks to detect ROOT_KEY_NOT_CONFIGURED and show setup instructions
- Add px auth format-jwk-key command to convert SSH public keys to JWK format
- Add CLI tests for format-jwk-key command